### PR TITLE
Support the ability to set orientation per page.

### DIFF
--- a/src/factory/Elements/PageElementFactory.tsx
+++ b/src/factory/Elements/PageElementFactory.tsx
@@ -13,7 +13,13 @@ export const createPageElement = (element: PageElementDeclaration, factory:IElem
     const finalStyle = context.buildFinalStyle(classes, style);
     logger.debug('<Page> Creating new page.')
     return (
-        <Page key={v4()} style={finalStyle} size={context.config.size} debug={context.config.debug} ruler={context.config.debug} >
+        <Page 
+            key={v4()} 
+            style={finalStyle} 
+            size={element.size ?? context.config.size ?? 'Letter'} 
+            orientation={element.orientation ?? context.config.orientation ?? 'portrait'} 
+            debug={context.config.debug} 
+            ruler={context.config.debug} >
         {
             children.map(child => factory.createElement(child))
         }

--- a/src/wire/ElementDeclaration.ts
+++ b/src/wire/ElementDeclaration.ts
@@ -24,6 +24,11 @@ export interface StylableElementDeclaration extends ElementDeclaration {
 
 export interface PageElementDeclaration extends StylableElementDeclaration
 {
+  // The paper size to use
+  size: string | undefined;
+  // Determines page orientation. Valid values are "portrait" or "landscape".
+  orientation: 'portrait' | 'landscape' | undefined;
+  // Child elements to lay out on the page
   children: ElementDeclaration[];
 }
 

--- a/src/wire/PdfRequest.ts
+++ b/src/wire/PdfRequest.ts
@@ -6,7 +6,9 @@ export interface PdfRequest {
   // The title is used both for the title meta-property in the pdf, and the returned file name
   title: string;
   // The paper size to use
-  size: string;
+  size: string | undefined;
+  // Determines page orientation. Valid values are "portrait" or "landscape".
+  orientation: 'portrait' | 'landscape' | undefined;
   // Whether to draw debugging rects around all items
   debug: boolean;
   // A collection of named styles that can be referenced


### PR DESCRIPTION
## Description
Imported a missed commit that allows you to specify an orientation for the document.
Extended this implementation to optionally support setting the orientation (and page size) per-page if needed.

## Motivation and Context
We have a new PDF design request whose final page is rotated to landscape, while all other pages are in portrait.

## How Has This Been Tested?
Used the Direct PDF Evaluation of the field health pdf to test various combinations of values at the document & page levels.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1141422/187285658-8a38122e-4024-4e2d-afc0-34fa0e3023b8.png)
