### PR TITLE
Infer node types by the presence of certain properties, and expanded …

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Render some basic text on the screen via the `text` property.
 
 Accepts full styling. 
 
-Cannot contain children.
+~~Cannot contain children.~~
+Can contain children, but they can _only_ be other Text elements.  This allows for inline spans with changing formatting; Ie a parent text element with one regular text part, one **bolded** text part, and a final regular text part, that all flows and is laid out as one text line.
 
 ### Images
 

--- a/README.md
+++ b/README.md
@@ -276,4 +276,55 @@ or _after_ the list , respectively, _on each page in which the list was rendered
 
 Cannot contain children, other than the individual items in `loop` `header` or `footer`.
 
+## Type inference
+
+In simple cases you can elide the `type` property by providing one of the discriminator properties.  That is, one of:
+
+* `text`: Infer a text type.
+* `src`: Infer an image type.
+* `children`: infer a view type.
+* `basis` and `loop`: infer a list type.
+
+In more complex cases (a text with children, for example) you will need to explicitly provide the `type`.
+
 ## Examples
+
+```json
+{
+    "text": "Hello World!",
+    "comment": "You can add a comment for readability.  This element will be auto-detected as text due to the text property"
+}
+```
+
+```json
+{
+    "src": "https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/static/geojson({{$item.FieldGeometry}})/auto/345x287?access_token={{data.MapBoxAccessToken}}",
+    "comment": "This is an image.  You can see we reference the data payload here to make the image dynamic. Basically any single-statement javascript can be embedded here so long as it resolves to something that can be inserted as text".
+}
+```
+
+```json
+{
+    "style": {
+        "display": "flex",
+        "flexDirection": "column",
+        "padding": 16,
+        "paddingTop": 4
+    },
+    "children": [
+        { 
+            "type":"text",
+            "comment": "text elements can have child text elements so that layout flows together",
+            "children": [
+                { "text": "Hello "},
+                { "text": "World", "style": {"fontWeight":"bold", "color": "blue" } },
+                { "text": "!" }
+            ]
+        },
+        {
+            "comment": "You can provide base 64 data uris for inlining images too", 
+            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
+        }
+    ]
+}
+```

--- a/src/factory/ElementFactory.tsx
+++ b/src/factory/ElementFactory.tsx
@@ -215,6 +215,11 @@ export class ElementFactory implements IElementContext, IElementFactory
     return vm.run(name);
   };
 
+  /**
+   * Attempt to infer what element type a node is by the presence of certain properties.
+   * @param element The element to infer the type for.
+   * @returns A strictly determined element type, or a thrown exception.
+   */
   private inferElementType(element: ElementDeclaration) : ElementTypes {
     let elementType: ElementTypes | undefined = undefined;
 
@@ -258,6 +263,7 @@ export class ElementFactory implements IElementContext, IElementFactory
       this.logger.error(`No node type could be inferred`);
       throw new Error(`No node type could be inferred`);
     }
+    
     return elementType;
   }
 }

--- a/src/factory/ElementFactory.tsx
+++ b/src/factory/ElementFactory.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {  Document } from '@react-pdf/renderer';
 import ReactPDF from '@react-pdf/renderer';
 import { PdfRequest } from '../wire/PdfRequest';
-import { ElementDeclaration } from '../wire/ElementDeclaration';
+import { ElementDeclaration, ElementTypes } from '../wire/ElementDeclaration';
 import { staticElementRegistry } from './ElementRegistry';
 import { IElementContext } from './IElementContext';
 import { IElementFactory } from './IElementFactory';
@@ -97,14 +97,25 @@ export class ElementFactory implements IElementContext, IElementFactory
         return <></>;
       }
     }
-    if(!staticElementRegistry.typeRegistry[element.type])
+
+    let elementType = element.type;
+    if(!elementType)
     {
-      this.logger.error(`No factory found for element of type ${element.type}`);
+      // Add some shortcuts
+      elementType = this.inferElementType(element);
     }
-    const rendered = staticElementRegistry.typeRegistry[element.type](element, this, this, this.logger);
+    
+    if(!staticElementRegistry.typeRegistry[elementType])
+    {
+      this.logger.error(`No factory found for element of type ${elementType}`);
+      throw new Error(`No factory found for element of type ${elementType}`);
+    }
+
+    const rendered = staticElementRegistry.typeRegistry[elementType](element, this, this, this.logger);
     if(!rendered)
     {
-      this.logger.error(`Attempted to render ${element.type} but got ${rendered}`, element);
+      this.logger.error(`Attempted to render ${elementType} but got ${rendered}`, element);
+      throw new Error(`Attempted to render ${elementType} but got ${rendered}`);
     }
     return rendered;
   };
@@ -203,6 +214,52 @@ export class ElementFactory implements IElementContext, IElementFactory
     });
     return vm.run(name);
   };
+
+  private inferElementType(element: ElementDeclaration) : ElementTypes {
+    let elementType: ElementTypes | undefined = undefined;
+
+    if ((element as any).text) {
+      elementType = 'text';
+    }
+
+    if ((element as any).src) {
+      if (!!elementType) {
+        this.logger.error(`Inferred a node type of ${elementType} but also found a 'src' attribute`);
+        throw new Error(`Inferred a node type of ${elementType} but also found a 'src' attribute`);
+      }
+      elementType = 'image';
+    }
+
+    if ((element as any).children) {
+      if (!!elementType) {
+        this.logger.error(`Inferred a node type of ${elementType} but also found a 'children' attribute`);
+        throw new Error(`Inferred a node type of ${elementType} but also found a 'children' attribute`);
+      }
+      elementType = 'view';
+    }
+
+    if ((element as any).basis && (element as any).loop) {
+      if (!!elementType) {
+        this.logger.error(`Inferred a node type of ${elementType} but also found a 'basis' attribute`);
+        throw new Error(`Inferred a node type of ${elementType} but also found a 'basis' attribute`);
+      }
+      elementType = 'list';
+    }
+
+    if ((element as any).basis && (element as any).loop) {
+      if (!!elementType) {
+        this.logger.error(`Inferred a node type of ${elementType} but also found a 'basis' attribute`);
+        throw new Error(`Inferred a node type of ${elementType} but also found a 'basis' attribute`);
+      }
+      elementType = 'list';
+    }
+
+    if (!elementType) {
+      this.logger.error(`No node type could be inferred`);
+      throw new Error(`No node type could be inferred`);
+    }
+    return elementType;
+  }
 }
 
 

--- a/src/wire/ElementDeclaration.ts
+++ b/src/wire/ElementDeclaration.ts
@@ -1,4 +1,4 @@
-export type ElementTypes = 'view'|'image'|'text';
+export type ElementTypes = 'view'|'image'|'text'|'list'|'shadow'|'page';
 
 export interface ElementDeclaration {
   type: ElementTypes;


### PR DESCRIPTION
…documentation to explain this.

## Description
Support inferring the view type if the `test`, `src`, `children` or `basis` properties are provided.
Throw errors if there are conflicts or ambiguity.

## Motivation and Context
Reduce the verbosity of the payload to be sent, and make our lives a little easier.

## How Has This Been Tested?
Postman requests against the engine to test the example code. 

## Screenshots (if appropriate):
