### PR TITLE
Upgrade lists to accept arrays

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,19 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        {
+            "name": "Launch via NPM",
+            "request": "launch",
+            "runtimeArgs": [
+                "run-script",
+                "debug"
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
     {
         "name": "Attach",
         "port": 9229,

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ property.
 
 You must specify a `basis` property and provide the reference to an array of items in your data payload,
 although technically you can insert javascript here that simply _results_ in an array.  You must then
-provide a `loop` property which defines a single child element that will be rendered for each item in the
+provide a `loop` property which defines a single child element (as an object) or an array of child elements that will be rendered for each item in the
 basis array.
 
 Optionally, you can provide `header` and `footer`, each of which is a simple element that is placed _before_

--- a/src/factory/Elements/ListElementFactory.tsx
+++ b/src/factory/Elements/ListElementFactory.tsx
@@ -21,7 +21,7 @@ export const createListElement = (element: ListElementDeclaration, factory:IElem
     logger.debug(`<List> dataBasis=${basis}`);
 
     // Map our dataBasis to all elements
-    const innerElements = (dataBasis.map((elementData, index) => {
+    const innerElements2D = dataBasis.map((elementData, index) => {
         // push a new scope with the iterated item as part of it, plus some supporting values
         context.pushData({[iteratedIndexName]:index, [iteratedItemName]:elementData, [iteratedParentName]:context.scope[iteratedItemName]});
         // Create the inner item for this element, using the above scope
@@ -35,7 +35,11 @@ export const createListElement = (element: ListElementDeclaration, factory:IElem
         // Remove the scope
         context.popData();
         return items;
-    }) as React.ReactElement[][]).flat();
+    }) as React.ReactElement[][];
+    const innerElements = innerElements2D.reduce((total, cur) => {
+        total.push(...cur);
+        return total;
+    }, [] as React.ReactElement[])
     return (
         <>
             {headerElement}

--- a/src/factory/Elements/ListElementFactory.tsx
+++ b/src/factory/Elements/ListElementFactory.tsx
@@ -21,15 +21,21 @@ export const createListElement = (element: ListElementDeclaration, factory:IElem
     logger.debug(`<List> dataBasis=${basis}`);
 
     // Map our dataBasis to all elements
-    const innerElements = dataBasis.map((elementData, index) => {
+    const innerElements = (dataBasis.map((elementData, index) => {
         // push a new scope with the iterated item as part of it, plus some supporting values
         context.pushData({[iteratedIndexName]:index, [iteratedItemName]:elementData, [iteratedParentName]:context.scope[iteratedItemName]});
         // Create the inner item for this element, using the above scope
-        const item = factory.createElement(loop);
+        let items = [];
+        if (Array.isArray(loop)) {
+            items = loop.map((loopChild) => factory.createElement(loopChild))
+        } else {
+            const item = factory.createElement(loop);
+            items.push(item);
+        }
         // Remove the scope
         context.popData();
-        return item;
-    }) as React.ReactElement[];
+        return items;
+    }) as React.ReactElement[][]).flat();
     return (
         <>
             {headerElement}

--- a/src/wire/ElementDeclaration.ts
+++ b/src/wire/ElementDeclaration.ts
@@ -19,7 +19,7 @@ export interface ListElementDeclaration extends ElementDeclaration
   header:ElementDeclaration;
   footer:ElementDeclaration;
   basis:string;
-  loop:ElementDeclaration;
+  loop: ElementDeclaration | ElementDeclaration[];
 }
 
 export interface StylableElementDeclaration extends ElementDeclaration {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2019"],                        /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["ES2019"],                        /* Specify library files to be included in the compilation. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
Lists have a `loop` property that supported a single element as a child in the form of an array. This PR upgrades the `loop` property on `list` elements to accept an array of children, with back-compatibility for still supporting the single child.

## Description
When creating elements from the list definition, the `loop` property is tested for being an array. All inner elements for each iteration of the loop are stored in an array, regardless of whether `loop` is an array or not, and then the 2-dimensional array is flattened into a 1-dimensional array at the end.

## Motivation and Context
To have multiple pages in different orientations for a single entry in the `basis` of a loop, so that a single piece of data can have display in multiple orientation of pages.

## How Has This Been Tested?
Locally tested; converted a loop within a view within a page into a loop of an array of pages, with one portrait and one landscape on every loop.

## Screenshots (if appropriate):
[looping pages.pdf](https://github.com/SkywardApps/pdf-render-service/files/9481003/looping.pages.pdf)
