### PR TITLE
Add standard fonts and update the font cache inthe dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,3 @@
-FROM alpine as pdf_base
-
-RUN apk update && apk add nodejs && apk upgrade busybox
-# These selections will cover most languages and are a good fit for most setups: 
-RUN apk add font-misc-misc
-RUN fc-cache -fv
-
-
-# Run everything after as non-privileged user.
-RUN install -m 775 -d /usr/src/app
-WORKDIR /app
-EXPOSE 9000
-
 # Build another image that's just for debugging.
 FROM pdf_base as pdf_debug
 # This is left empty because compose will mount
@@ -37,7 +24,12 @@ RUN npm prune --production
 # run node prune
 RUN npx node-prune
 
-FROM pdf_base as pdf_release
+FROM node:14 as pdf_release
+
+# Run everything after as non-privileged user.
+RUN install -m 775 -d /usr/src/app
+WORKDIR /app
+EXPOSE 9000
 
 # create a new user and change directory ownership
 RUN adduser --disabled-password \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM alpine as pdf_base
 
 RUN apk update && apk add nodejs && apk upgrade busybox
+# These selections will cover most languages and are a good fit for most setups: 
+RUN apk add font-misc-misc
+RUN fc-cache -fv
+
 
 # Run everything after as non-privileged user.
 RUN install -m 775 -d /usr/src/app


### PR DESCRIPTION
Dockerfile was crashing with error:

```RangeError [ERR_ENCODING_NOT_SUPPORTED]: The "ascii" encoding is not supported
2022-09-06T19:56:56.985779747Z     at new NodeError (node:internal/errors:372:5)
2022-09-06T19:56:56.985784147Z     at new TextDecoder (node:internal/encoding:400:15)
2022-09-06T19:56:56.985788348Z     at Object.<anonymous> (/app/node_modules/fontkit/dist/main.cjs:5414:51)
2022-09-06T19:56:56.985793648Z     at Module._compile (node:internal/modules/cjs/loader:1105:14)
2022-09-06T19:56:56.985797849Z     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
2022-09-06T19:56:56.985802249Z     at Module.load (node:internal/modules/cjs/loader:981:32)
2022-09-06T19:56:56.985807249Z     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
2022-09-06T19:56:56.985811850Z     at Module.require (node:internal/modules/cjs/loader:1005:19)
2022-09-06T19:56:56.985816350Z     at Module.patchedRequire [as require] (/agents/node/node_modules/diagnostic-channel/dist/src/patchRequire.js:16:46)
2022-09-06T19:56:56.985821851Z     at require (node:internal/modules/cjs/helpers:102:18) {
2022-09-06T19:56:56.985826051Z   code: 'ERR_ENCODING_NOT_SUPPORTED'
2022-09-06T19:56:56.985830352Z }```

To resolve, I added some font initialization in the dockerfile for the alpine base.