### PR TITLE
explicitly check for undefined when inferring types

### DIFF
--- a/src/factory/ElementFactory.tsx
+++ b/src/factory/ElementFactory.tsx
@@ -223,11 +223,11 @@ export class ElementFactory implements IElementContext, IElementFactory
   private inferElementType(element: ElementDeclaration) : ElementTypes {
     let elementType: ElementTypes | undefined = undefined;
 
-    if ((element as any).text) {
+    if ((element as any).text !== undefined) {
       elementType = 'text';
     }
 
-    if ((element as any).src) {
+    if ((element as any).src !== undefined) {
       if (!!elementType) {
         this.logger.error(`Inferred a node type of ${elementType} but also found a 'src' attribute`);
         throw new Error(`Inferred a node type of ${elementType} but also found a 'src' attribute`);
@@ -235,7 +235,7 @@ export class ElementFactory implements IElementContext, IElementFactory
       elementType = 'image';
     }
 
-    if ((element as any).children) {
+    if ((element as any).children !== undefined) {
       if (!!elementType) {
         this.logger.error(`Inferred a node type of ${elementType} but also found a 'children' attribute`);
         throw new Error(`Inferred a node type of ${elementType} but also found a 'children' attribute`);
@@ -243,7 +243,7 @@ export class ElementFactory implements IElementContext, IElementFactory
       elementType = 'view';
     }
 
-    if ((element as any).basis && (element as any).loop) {
+    if ((element as any).basis && (element as any).loop !== undefined) {
       if (!!elementType) {
         this.logger.error(`Inferred a node type of ${elementType} but also found a 'basis' attribute`);
         throw new Error(`Inferred a node type of ${elementType} but also found a 'basis' attribute`);


### PR DESCRIPTION
Change the conditions in the automatic type inferring to explicitly check against undefined.

## Description
Explicitly check for undefined because an empty string is falsey in JavaScript.

## Motivation and Context
Before this PR, an empty `text` string or an empty `src` string will fail to correctly infer the element type as text or image, respectively.

## How Has This Been Tested?
Generated a PDF locally with an implicitly-defined text element with an empty string as the content.
```json
{
  "text": ""
}
```