### PR TITLE
Extract types from react-pdf manually since v1 types are not exported and react-pdf/types is not a match.

### DIFF
--- a/src/ReactPdfTypeHacks.ts
+++ b/src/ReactPdfTypeHacks.ts
@@ -1,0 +1,189 @@
+export interface Style {
+  //Flexbox
+
+  alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around',
+  alignItems?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline',
+  alignSelf?: 'auto' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch',
+  flex?: number,
+  flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse',
+  flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse',
+  flexFlow?: number,
+  flexGrow?: number,
+  flexShrink?: number,
+  flexBasis?: number,
+  justifyContent?: 'flex-start' | 'flex-end' | 'center' | 'space-around' | 'space-between' | 'space-evenly',
+  order?: number,
+
+  // Layout?:never,
+
+  bottom?: number | string,
+  display?: 'flex' | 'none',
+  left?: number | string,
+  position?: 'absolute' | 'relative',
+  right?: number | string,
+  top?: number | string,
+
+  // Dimension?:never,
+
+  height?: number | string,
+  maxHeight?: number | string,
+  maxWidth?: number | string,
+  minHeight?: number | string,
+  minWidth?: number | string,
+  width?: number | string,
+
+  // Color?:never,
+
+  backgroundColor?: string,
+  color?: string,
+  opacity?: number,
+
+  // Text?:never,
+
+  fontSize?: number | string,
+  fontFamily?: string,
+  fontStyle?: string | 'normal',
+  fontWeight?: number | 'thin' | 'hairline' | 'ultralight' | 'extralight' | 'light' | 'normal' | 'medium' | 'semibold' | 'demibold' | 'bold' | 'ultrabold' | 'extrabold' | 'heavy' | 'black',
+  letterSpacing?: number | string,
+  lineHeight?: number | string,
+  maxLines?: number, //?
+  textAlign?: 'left' | 'right' | 'center' | 'justify', //?
+  textDecoration?: 'line-through' | 'underline' | 'none',
+  textDecorationColor?: string,
+  textDecorationStyle?: "dashed" | "dotted" | "solid" | string, //?
+  textIndent?: any, //?
+  textOverflow?: any, //?
+  textTransform?: 'capitalize' | 'lowercase' | 'uppercase',
+
+  // Sizing/positioning?:never,
+
+  objectFit?: string,
+  objectPosition?: number | string,
+  objectPositionX?: number | string,
+  objectPositionY?: number | string,
+
+  // Margin/padding?:never,
+
+  margin?: number | string,
+  marginHorizontal?: number | string,
+  marginVertical?: number | string,
+  marginTop?: number | string,
+  marginRight?: number | string,
+  marginBottom?: number | string,
+  marginLeft?: number | string,
+  padding?: number | string,
+  paddingHorizontal?: number | string,
+  paddingVertical?: number | string,
+  paddingTop?: number | string,
+  paddingRight?: number | string,
+  paddingBottom?: number | string,
+  paddingLeft?: number | string,
+
+  // Transformations?:never,
+
+  transform?: string,
+  transformOrigin?: number | string,
+  transformOriginX?: number | string,
+  transformOriginY?: number | string,
+
+  // Borders?:never,
+
+  border?: number | string,
+  borderWidth?: number,
+  borderColor?: string,
+  borderStyle?: "dashed" | "dotted" | "solid",
+  borderTop?: number | string,
+  borderTopColor?: string,
+  borderTopStyle?: "dashed" | "dotted" | "solid", // ?
+  borderTopWidth?: number | string,
+  borderRight?: number | string,
+  borderRightColor?: string,
+  borderRightStyle?: "dashed" | "dotted" | "solid", //?
+  borderRightWidth?: number | string,
+  borderBottom?: number | string,
+  borderBottomColor?: string,
+  borderBottomStyle?: "dashed" | "dotted" | "solid", //?
+  borderBottomWidth?: number | string,
+  borderLeft?: number | string,
+  borderLeftColor?: string,
+  borderLeftStyle?: "dashed" | "dotted" | "solid", //?
+  borderLeftWidth?: number | string,
+  borderTopLeftRadius?: number | string,
+  borderTopRightRadius?: number | string,
+  borderBottomRightRadius?: number | string,
+  borderBottomLeftRadius?: number | string,
+  borderRadius?: number | string
+}
+
+export type FontWeight =
+| number
+| 'thin'
+| 'ultralight'
+| 'light'
+| 'normal'
+| 'medium'
+| 'semibold'
+| 'bold'
+| 'ultrabold'
+| 'heavy';
+
+export type Orientation = 'portrait' | 'landscape';
+
+export type StandardPageSize =
+  | '4A0'
+  | '2A0'
+  | 'A0'
+  | 'A1'
+  | 'A2'
+  | 'A3'
+  | 'A4'
+  | 'A5'
+  | 'A6'
+  | 'A7'
+  | 'A8'
+  | 'A9'
+  | 'A10'
+  | 'B0'
+  | 'B1'
+  | 'B2'
+  | 'B3'
+  | 'B4'
+  | 'B5'
+  | 'B6'
+  | 'B7'
+  | 'B8'
+  | 'B9'
+  | 'B10'
+  | 'C0'
+  | 'C1'
+  | 'C2'
+  | 'C3'
+  | 'C4'
+  | 'C5'
+  | 'C6'
+  | 'C7'
+  | 'C8'
+  | 'C9'
+  | 'C10'
+  | 'RA0'
+  | 'RA1'
+  | 'RA2'
+  | 'RA3'
+  | 'RA4'
+  | 'SRA0'
+  | 'SRA1'
+  | 'SRA2'
+  | 'SRA3'
+  | 'SRA4'
+  | 'EXECUTIVE'
+  | 'FOLIO'
+  | 'LEGAL'
+  | 'LETTER'
+  | 'TABLOID'
+  | 'ID1';
+
+export type StaticSize = number | string;
+
+// From PageProps
+export type PageSize = string | [number, number] | { width: number; height: number };
+  

--- a/src/factory/ElementFactory.tsx
+++ b/src/factory/ElementFactory.tsx
@@ -7,7 +7,7 @@ import { IElementContext } from './IElementContext';
 import { IElementFactory } from './IElementFactory';
 import { VM } from 'vm2';
 import { ILogger } from '../ILogger';
-import { Style } from '@react-pdf/types';
+import { Style } from '../ReactPdfTypeHacks';
 import { fontIsRegistered, loadReferencedFonts } from '../fontManagement';
 import { createElementKey } from './createElementKey';
 

--- a/src/factory/Elements/PageElementFactory.tsx
+++ b/src/factory/Elements/PageElementFactory.tsx
@@ -8,7 +8,7 @@ import { v4 } from 'uuid';
 import {
   PageSize,
   Orientation
-} from '@react-pdf/types';
+} from '../../ReactPdfTypeHacks';
 import { createElementKey } from "../createElementKey";
 
 // Create a new page.  This must be at the top level, and are the only items allowed at the top level.

--- a/src/factory/Elements/ShadowElementFactory.tsx
+++ b/src/factory/Elements/ShadowElementFactory.tsx
@@ -2,7 +2,6 @@ import { StyleWithShadow, TextElementDeclaration } from '../../wire/ElementDecla
 import { IElementFactory } from '../IElementFactory';
 import { IElementContext } from '../IElementContext';
 import { View, Text } from '@react-pdf/renderer';
-import { Style } from '@react-pdf/types';
 import React from 'react';
 import { ILogger } from '../../ILogger';
 import { v4 } from 'uuid';

--- a/src/factory/IElementContext.ts
+++ b/src/factory/IElementContext.ts
@@ -1,5 +1,5 @@
 import { PdfRequest } from '../wire/PdfRequest';
-import { Style } from '@react-pdf/types';
+import { Style } from '../ReactPdfTypeHacks';
 import { StyleWithEvaluation } from '../wire/ElementDeclaration';
 
 export interface IElementContext

--- a/src/fontManagement.ts
+++ b/src/fontManagement.ts
@@ -1,7 +1,7 @@
 import { Font } from '@react-pdf/renderer';
 import axios from 'axios';
 import { ILogger } from './ILogger';
-import { FontWeight } from '@react-pdf/types';
+import { FontWeight } from './ReactPdfTypeHacks';
 
 /**
  * An internal map of all the fonts we have already loaded, since there doesn't seem to be a system for it as part of react-pdf

--- a/src/wire/ElementDeclaration.ts
+++ b/src/wire/ElementDeclaration.ts
@@ -2,7 +2,7 @@ import {
   Style,
   StandardPageSize,
   Orientation,
-} from '@react-pdf/types';
+} from '../ReactPdfTypeHacks';
 
 export type ElementTypes = 'view'|'image'|'text'|'list'|'shadow'|'page'|'link';
 

--- a/src/wire/PdfRequest.ts
+++ b/src/wire/PdfRequest.ts
@@ -2,7 +2,7 @@ import {
   Style,
   StandardPageSize,
   Orientation,
-} from '@react-pdf/types';
+} from '../ReactPdfTypeHacks';
 import { ElementDeclaration, PageElementDeclaration, StyleWithEvaluation } from './ElementDeclaration';
 
 // This defines the expected incoming request format


### PR DESCRIPTION
Fixed docker build by replacing react-pdf/types which doesnt match the v1 types with manually extracted types./