### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,3 @@ dist
 !.yarn/sdks
 !.yarn/versions
 
-# Memory bank (project documentation for AI context)
-memory-bank/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# Your approach (CRITICALLY IMPORTANT)
+
+It is always acceptable to reply that you don't know the answer to something. You may always ask clarifying questions, prompt for more information, or perform additional research to become more confident in a response or task. You may push back and request confirmation if something doesn't make sense, isn't correct, or isn't the right course of action. Be critical, skeptical, and cautious, but ultimately perform the task requested and don't be a roadblock, just make sure it is the best quality it can be.
+
+Use short sentences. No filler, preamble, or pleasantries. Run tools first, show the result, then stop. Do not narrate unless the situation is exceptional.
+
+# Memory Bank (Token-Optimized Specification)
+
+The Memory Bank is my **only** persistent context. Core files are inlined below via @ imports.
+
+## Structure (All Markdown, Hierarchical, Machine-Targeted)
+
+```
+projectBrief.md
+ ├─ productContext.md
+ ├─ systemPatterns.md
+ └─ techContext.md
+```
+
+### Core Files (Minimal, Precise)
+
+**projectBrief.md**
+
+* Project baseline: purpose, requirements, scope.
+* Primary reference for all other files.
+
+**productContext.md**
+
+* Problem → solution summary
+* Functional intent
+* UX expectations
+
+**systemPatterns.md**
+
+* Architecture
+* Major design choices
+* Component relationships
+* Critical flows
+
+**techContext.md**
+
+* Tech stack
+* Constraints
+* Setup details
+* Dependencies
+* Tooling patterns
+
+
+### Additional Context (Only When Needed)
+
+Add files under `memory-bank/` for:
+
+* Complex features
+* Integrations
+* APIs
+* Testing
+* Deployment
+
+Keep all content concise and LLM-optimized.
+
+## Core Workflows
+
+### Plan Mode (Claude Code's native plan mode)
+- Review memory bank context (already inlined via @ imports).
+- Design strategy. Do not make edits — write plan to plan file only.
+
+### Act Mode (Claude Code's default mode)
+- Review memory bank context (already inlined via @ imports).
+- Update docs if project understanding changes.
+- Execute task, then document significant changes in memory bank.
+
+## Update Rules
+
+Update Memory Bank when:
+
+1. New patterns emerge
+2. Significant changes occur
+3. User triggers **update memory bank** (requires full file review)
+4. Context becomes ambiguous
+
+Update process:
+
+```
+ReviewAllFiles → RecordCurrentState → ClarifyNextSteps → CaptureInsights
+```
+
+When **update memory bank** is invoked, always re-read and reassess **every** file.
+
+## Core Principle
+
+After each memory reset, I have zero context.
+The Memory Bank must be **precise, minimal, unambiguous, and optimized for LLM consumption**.
+Its accuracy directly determines my effectiveness.
+
+## Memory Precedence
+The memory-bank files (inlined below) are the authoritative project context.
+They take precedence over Claude Code's auto memory (~/.claude/projects/.../memory/).
+If the two conflict, trust and follow memory-bank. Update auto memory to resolve the conflict.
+
+@memory-bank/projectBrief.md
+@memory-bank/productContext.md
+@memory-bank/systemPatterns.md
+@memory-bank/techContext.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,7 +1,7 @@
 When contributing to this repository, please first discuss the change you wish to make via issue,
 email, or any other method with the owners of this repository before making a change.  
 
-Please note we have a [code of conduct](../CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [code of conduct](./CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -1,330 +1,75 @@
-# PDF Render engine and service
-This project provides a PDF layout and rendering engine, along with a web service 
-to render the PDF on-demand.
+# PDF Render Engine and Service
 
-### Why this?
-Creating a PDF is hard.  You can use many great editors, but ONLY for fixed content.  If you have dynamic context,
-like a changing product list of variable length, or different titles and names, there's no great solution.  The
-goal of this service is to create something that is:
+A PDF layout and rendering engine — and an HTTP service around it — that turns a JSON request into a PDF binary. Built on [react-pdf](https://react-pdf.org/) and the [Yoga](https://yogalayout.com/) layout engine.
 
-* Data Driven for both content and structure
-* Easy to modify on the fly
-* Uses common layout standards
-* Usable as a service
-
-### Okay, but why not wkhtmltopdf or one of the other render-a-website-as-pdf services?
-The killer feature here is being able to have repeatable entry and exit sections on a 
-variable sized list.  If you have a table with a header row, for example, and the table flows onto the next page, 
-ideally you want: The page header (if any) to be included, possibly with a dynamic page number, then the header
-row to be repeated, and then keep going with the content.  None of the existing services actually support that 
-full requirement.
-
-Plus, they all tend to be very finicky.  This service may be finicky too, but in a way we can debug and fix it, versus 
-relying on how a headless browser on a server somewhere is responding with the latest chromium updates.
-
-### Cool, but, Data Driven? That doesn't sound like fun to work with
-Working directly with the data for the structure isn't hugely hard, but large PDFs become difficult.
-The _end_ goal for all of this is to create a graphical template editor, which you can only do if your PDF is 
-driven by data.   Otherwise, you're always dependent on a developer working on your (graphical) content.
-
-This also separates the data aspect (which can be fed from an API, for example) from the visual structure, which 
-can allow division of responsibilities.
-
-https://react-pdf.org/
-https://yogalayout.com/
-https://craft.js.org/
-https://en.wikipedia.org/wiki/PDF
-
-## Features
-
-### Layout
-
-This service is based on react-pdf, which in turn uses the Yoga layout engine.  
-This means that layout is largely based on flexbox with a minimal CSS syntax.
-The hope is that this means a lot of layout knowledge can transfer from web design
-experience.
-
-### Styling
-
-#### Inline Styles
-
-This service supports a subset of CSS properties ( See https://react-pdf.org/styling#valid-css-properties ) 
-that can be assigned directly to an element. This includes basic layout and visual styles.
-
-```json
-    {
-        "type":"text",
-        "text":"Hello World",
-        "style":{
-            "fontSize":18,
-            "color":"#000000",
-            "margin":5,
-            "position":"absolute",
-            "top":0,
-            "left":0
-        }
-    }
+```bash
+yarn && yarn start
+curl -X POST http://localhost:9000/ \
+  -H "Content-Type: application/json" \
+  -o hello.pdf \
+  -d '{"title":"Hello","pages":[{"children":[{"text":"Hello, World!"}]}]}'
 ```
 
-### Classes
-Similar to css, you can create named styles that you can apply as classes to individual elements.
-Unlike css, the application of properties is dependent on the order of the classname in the list.
-This means that classes are applied in list order, with subsequent classes overwriting properties
-of earlier ones, and finally any explicit element style is applied.
+See [docs/getting-started.md](docs/getting-started.md) for the full quickstart.
 
-```json
-{
-    "styles": {
-        "zeroPad": {
-            "margin": 0,
-            "padding": 0
-        },
-        "smallPad": {
-            "padding": 2
-        },
-        "guideTitle": {
-            "fontSize": 24,
-            "fontWeight": "bold",
-            "textAlign": "center",
-            "color": "#F7A03A"
-        }
-    },
-    ...
-    "pages":[
-        ...
-            {
-                "type":"text",
-                "classes":["zeroPad", "smallPad", "guideTitle"], // padding set to 2 as smallPad overwrites zeroPad's prop,
-                "style":{
-                    "color":"#000000" // color is black as this overwrites the guideTitle prop
-                }
-            }
-        ...
-    ]
-}
+## Why this?
+
+Creating a PDF is hard. Editors handle fixed content well, but anything dynamic — a variable-length product list, changing titles and names — quickly runs out of road. This service aims to be:
+
+- **Data-driven** for both content and structure.
+- **Easy to modify on the fly** — no recompilation, no template language to learn beyond JSON + a templating syntax.
+- **Standards-based layout** — flexbox via Yoga.
+- **Service-shaped** — POST a JSON body, get a PDF binary back.
+
+## Why not wkhtmltopdf or another HTML-to-PDF service?
+
+The killer feature here is **re-entrant headers and footers on variable-length content**. If you have a table whose header row should repeat at the top of every page the table spans, none of the headless-browser converters handle that cleanly. They're also fragile under upstream Chromium updates — when something breaks, you're at the mercy of a third party. This service owns the rendering path so it can be debugged and fixed in-house.
+
+## Why JSON / data-driven?
+
+The end goal is a graphical template editor. That only works if the layout is data, not code — otherwise a developer is always in the loop for visual changes. Keeping data and structure separable also lets a backend produce the data while a designer owns the structure, with neither blocking the other.
+
+## Documentation
+
+Human-targeted docs live in [docs/](docs/):
+
+- **[Getting started](docs/getting-started.md)** — install, run, first PDF.
+- **[HTTP API](docs/api.md)** — endpoints, request envelope, errors, limits.
+- **[Element reference](docs/elements.md)** — every element type and property (page, view, text, image, link, list, shadow).
+- **[Templating](docs/templating.md)** — `{{...}}` syntax, scope rules, sandbox limits.
+- **[Styling](docs/styling.md)** — class precedence, supported CSS, common patterns.
+- **[Fonts](docs/fonts.md)** — bundled defaults, on-demand Google Fonts loading.
+- **[Deployment](docs/deployment.md)** — Docker, environment variables, security notes.
+
+The `memory-bank/` directory contains a terser, LLM-targeted snapshot of the same material; humans will get more out of `docs/`.
+
+## Project layout
+
+```
+src/
+  index.ts                 entrypoint (winston + http listener)
+  Server.ts                routing (GET /, GET /fonts, OPTIONS, POST /)
+  PdfController.ts         POST handler — buffer body, validate, render, stream PDF back
+  validatePdfRequest.ts    AJV against src/resources/PdfRequest.json
+  fontManagement.ts        registry + Google Fonts loader
+  wire/                    PdfRequest + ElementDeclaration types (schema source of truth)
+  factory/                 ElementFactory + per-type Elements/
+  helpers/                 small utilities
+fonts/                     bundled font files (Roboto, Teko, Noto Sans)
+docs/                      human-targeted documentation
+memory-bank/               LLM-targeted project snapshot
 ```
 
-### Dynamic Data and Templating
+## License
 
-You can provide an arbitrary data model as the 'data' property, and your structure is able to access it in 
-any property.  In fact, your structure can access the entire data structure!
+MIT — see [LICENSE](LICENSE).
 
-In order to reference data inline, you can use a `{{variablename}}` syntax.  So for example, if you provided 
-a data structure:
-```json
-{
-    "title":"Hello World"
-}
-```
+## Contributing
 
-Then you could reference that anywhere in your structure like so:
-```json
-{
-    "text": "Title: {{data.title}}",
-    ...
-}
-```
+See [Contributing.md](Contributing.md) and the [Code of Conduct](CODE_OF_CONDUCT.md). Issues and pull requests are tracked on GitHub.
 
-You can use it in image src properties:
-```json
-{
-    "src": "https://images.com/{{data.imageUrl}}",
-    ...
-}
-```
+## Reference links
 
-Or in styles:
-```json
-"style":{
-    "marginLeft":"{{data.standardMargin}}",
-    ...
-}
-```
-
-In fact, the code between `{` `}` can be any arbitrary javascript!
-```json
-{
-    "text":"{{[1,2,3,4].filter(i => i > 2).map(i => 'Index:' + (i+1))}}"
-}
-```
-
-> Executing javascript (beyond simple derefences like `data.value`) can be _very_ expensive
-and cause the PDF generation to be _very_ slow.
-
-### Logical layouts 
-
-You can use logical elements to affect changes on the structure based on the data.  Currently we have only 
-implemented 'list', but 'if' is the next candidate. 
-
-Basically, this means that you can use a list to iterate and apply a specific template over an array of elements in
-your data.
-
-For example, if you have:
-```json
-{
-    "data":{
-        "items":[
-            "One",
-            "Two",
-            "Three"
-        ]
-    }
-}
-```
-You can loop over that array with a list, referencing each data element with the locally-scoped '$item' variable:
-
-```json
-{
-    "type":"list",
-    "basis":"data.items",
-    "loop":{
-        "type":"text",
-        "text":"Item {{$item}}"
-    }
-}
-```
-
-### Re-entrant page breaks
-You can designate any item 'fixed' to it's place on a page by setting 'fixed':true on it.  This means on each 
-page break, this item will be re-rendered to its location.
-https://react-pdf.org/advanced#fixed-components
-
-You can also specify that items cannot be subdivided across page breaks by setting 'wrap':false.  This means if
-the item won't fit on the page, it will be moved to a new page instead.
-https://react-pdf.org/advanced#page-wrapping
-
-A feature specific to our engine are 're-entrant blocks'.  This means that when you create an element, you can 
-define a header and footer that are only scoped to that item (as opposed to the page in general).  This means 
-that if you have, for example, a grid of contents with a header row, that header can be repeated on any page
-break.
-
-```json
-{
-    "type":"list",
-    "basis":"data.items",
-    "loop":{
-        "type":"text",
-        "text":"[{{$item.Name}}] [{{$item.Cost}}]"
-    },
-    "header":{
-        "type":"text",
-        "text":"[Item Name] [Cost($)]",
-    },
-    "footer":{
-        "type":"image",
-        "src":"https://footers.org/prettypicture.jpg"
-    }
-}
-```
-
-## Usage
-
-### Invoking the service
-
-This isn't designed to be complicated; it supports three operations:
-
-* GET: Return a basic status of readiness.
-* OPTIONS: Supports making CORS calls from other domains
-* POST: Submit a json payload representing the PDF to be rendered.  The result is a direct PDF 
-binary download, or an HTTP error code with details in the body.
-
-### Pages (Container)
-
-Pages are top-level elements, and are the only elements that can exist at the top level.  
-They accept basic styling, and have a `children` property for the page's structure.
-
-### Views (Container)
-
-Views are the basic containers that hold content.  Views can contain other containers, or content elements.
-They can accept full styling, and have a `children` property for child content.
-Typically, you'd either make a container view `'display':'flex'` and designate how it lays out the children,
-or `'positioning':'relative'` and then each child lays itself out with `'positioning':'absolute` and the 
-`top` `left` `right` and `bottom` properties. 
-
-### Text
-
-Render some basic text on the screen via the `text` property. 
-
-Accepts full styling. 
-
-~~Cannot contain children.~~
-Can contain children, but they can _only_ be other Text elements.  This allows for inline spans with changing formatting; Ie a parent text element with one regular text part, one **bolded** text part, and a final regular text part, that all flows and is laid out as one text line.
-
-### Images
-
-Render an image on the screen from the `src` property. This can be a url to an accessible image online,
-or a data-url for image content inline (or sourced from the data property via templating).
-https://css-tricks.com/data-uris/
-
-Accepts full styling. 
-
-Cannot contain children.
-
-### Lists (Container)
-
-Lists are logical elements, that don't independently affect styling or positioning.  There is no element
-added to the rendered document that strictly represents a list.  This means it does NOT have a style 
-property.
-
-You must specify a `basis` property and provide the reference to an array of items in your data payload,
-although technically you can insert javascript here that simply _results_ in an array.  You must then
-provide a `loop` property which defines a single child element (as an object) or an array of child elements that will be rendered for each item in the
-basis array.
-
-Optionally, you can provide `header` and `footer`, each of which is a simple element that is placed _before_
-or _after_ the list , respectively, _on each page in which the list was rendered_.
-
-Cannot contain children, other than the individual items in `loop` `header` or `footer`.
-
-## Type inference
-
-In simple cases you can elide the `type` property by providing one of the discriminator properties.  That is, one of:
-
-* `text`: Infer a text type.
-* `src`: Infer an image type.
-* `children`: infer a view type.
-* `basis` and `loop`: infer a list type.
-
-In more complex cases (a text with children, for example) you will need to explicitly provide the `type`.
-
-## Examples
-
-```json
-{
-    "text": "Hello World!",
-    "comment": "You can add a comment for readability.  This element will be auto-detected as text due to the text property"
-}
-```
-
-```json
-{
-    "src": "https://api.mapbox.com/styles/v1/mapbox/satellite-streets-v9/static/geojson({{$item.FieldGeometry}})/auto/345x287?access_token={{data.MapBoxAccessToken}}",
-    "comment": "This is an image.  You can see we reference the data payload here to make the image dynamic. Basically any single-statement javascript can be embedded here so long as it resolves to something that can be inserted as text".
-}
-```
-
-```json
-{
-    "style": {
-        "display": "flex",
-        "flexDirection": "column",
-        "padding": 16,
-        "paddingTop": 4
-    },
-    "children": [
-        { 
-            "type":"text",
-            "comment": "text elements can have child text elements so that layout flows together",
-            "children": [
-                { "text": "Hello "},
-                { "text": "World", "style": {"fontWeight":"bold", "color": "blue" } },
-                { "text": "!" }
-            ]
-        },
-        {
-            "comment": "You can provide base 64 data uris for inlining images too", 
-            "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
-        }
-    ]
-}
-```
+- [react-pdf](https://react-pdf.org/) — the underlying renderer.
+- [Yoga layout engine](https://yogalayout.com/) — the flexbox implementation react-pdf uses.
+- [PDF format reference](https://en.wikipedia.org/wiki/PDF) — for when you need to understand what's coming out the other end.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,134 @@
+# HTTP API
+
+The service exposes a small surface: a health check, a font list, and a single render endpoint.
+
+## Endpoints
+
+### `GET /`
+
+Health check. Returns `SUCCESS` (text body) with HTTP 200 when the service is up.
+
+### `GET /fonts`
+
+Returns the list of currently registered font families (the bundled defaults plus any Google Fonts that have been loaded on demand during this process's lifetime).
+
+```bash
+curl http://localhost:9000/fonts
+```
+
+Response (`application/json`):
+
+```json
+[
+  {
+    "family": "Roboto",
+    "configurations": [
+      { "weight": "normal", "style": "normal" },
+      { "weight": "bold",   "style": "normal" },
+      { "weight": "normal", "style": "italic" },
+      { "weight": "bold",   "style": "italic" }
+    ]
+  }
+]
+```
+
+Note: registration here means the source URL is recorded — a font is not validated as actually loadable until it is referenced during rendering.
+
+### `OPTIONS *`
+
+CORS preflight. The service responds 204 with these headers on every endpoint:
+
+| Header                         | Value                  |
+| ------------------------------ | ---------------------- |
+| `Access-Control-Allow-Origin`  | `*`                    |
+| `Access-Control-Allow-Methods` | `OPTIONS, POST, GET`   |
+| `Access-Control-Max-Age`       | `2592000` (30 days)    |
+
+### `POST /`
+
+The render endpoint. Send a JSON body conforming to the `PdfRequest` schema. The response is the PDF binary on success.
+
+| On success                                                                            |
+| ------------------------------------------------------------------------------------- |
+| `Content-type: application/pdf`                                                       |
+| `Content-disposition: attachment; filename="<sanitized title>.pdf"`                   |
+| HTTP 200, body = PDF bytes                                                            |
+
+The filename comes from the `title` field with everything outside `[A-Za-z0-9_.-]` replaced with `_`.
+
+## Request envelope (`PdfRequest`)
+
+| Field         | Type                               | Default          | Notes                                                            |
+| ------------- | ---------------------------------- | ---------------- | ---------------------------------------------------------------- |
+| `title`       | `string`                           | `"PDF Document"` | PDF metadata title; also drives the response filename.           |
+| `size`        | `StandardPageSize`                 | `"Legal"`        | Default page size; pages may override per-page.                  |
+| `orientation` | `"portrait" \| "landscape"`        | `"portrait"`     | Default orientation; pages may override per-page.                |
+| `debug`       | `boolean`                          | `false`          | When true, every element renders with debug rectangles.          |
+| `styles`      | `{ [name: string]: Style }`        | `{}`             | Named style classes. See [styling.md](styling.md).               |
+| `data`        | `any`                              | `{}`             | The data model exposed to `{{...}}` templates.                   |
+| `pages`       | `PageElementDeclaration[]`         | required         | The page tree. Top-level elements must be pages.                 |
+| `strict`      | `boolean`                          | `false`          | Per-request opt-in to JSON-schema validation.                    |
+| `prerender`   | `boolean`                          | `false`          | Pre-evaluates text templates to enable paragraph measurement.    |
+
+`StandardPageSize` is the type re-exported from `@react-pdf/types` — common values include `"LETTER"`, `"LEGAL"`, `"TABLOID"`, and the ISO `A`/`B`/`C` series (`"A4"`, `"A5"`, …). See the `@react-pdf/types` definitions for the full set.
+
+A minimal valid request:
+
+```json
+{
+  "title": "Minimum",
+  "pages": [
+    { "type": "page", "children": [ { "text": "hi" } ] }
+  ]
+}
+```
+
+## Validation
+
+The body is parsed as JSON. Validation against the generated JSON schema (`src/resources/PdfRequest.json`) runs when **either**:
+
+- the request body sets `"strict": true`, or
+- the service is started with `VALIDATEAPIPAYLOADS=strict` in the environment.
+
+When validation fails, the response is `400` with a plaintext body containing the AJV error array.
+
+## Limits
+
+- **Body size**: hard cap at **30 MB**. Larger requests have their connection destroyed and the request is logged as a flood candidate. (Inline data-URI images are the usual reason this matters.)
+- **Template script timeout**: 150 ms per `{{...}}` evaluation that requires the JS sandbox.
+
+## Error responses
+
+| Status | When                                                                                                          | Body                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `400`  | Schema validation failed (when strict).                                                                       | `The request was not valid: <ajv errors json>.`                               |
+| `400`  | Element-tree generation threw an `Error` (e.g. unknown element type, font lookup failed, template threw).     | `Error (<name>) rendering the file: <message>\nRender Stack: <breadcrumb>`    |
+| `500`  | `react-pdf` rendering threw, or the temp file could not be read back.                                         | `Error rendering the file: <error>.`                                          |
+| `404`  | Any request that isn't `OPTIONS`, `GET /`, `GET /fonts`, or `POST /`.                                         | empty                                                                         |
+
+### Render-stack breadcrumb
+
+When generation fails inside the element tree, the service emits a `Render Stack: a > b > c` trail in the response body. Each segment names the element type and its position. The format of each segment:
+
+- Top of stack: `document[<page-index>]`.
+- A child position: `<parent-key>.child[<index>]` (or `.loop`, `.loop[<index>]`, `.header`, `.footer` for list subtrees).
+- The failing element itself: `<type>` alone, or annotated with the first available identifier — `<type>[key=...]`, `<type>[comment=...]`, `<type>[text=...]`, `<type>[src=...]`, or `<type>[basis=...]` (truncated to 50 chars).
+
+Example:
+
+```
+Error (Error) rendering the file: No factory found for element of type widget
+Render Stack: document[0] > page.child[2] > view.child[1] > widget
+```
+
+Setting `key` on suspect elements in your payload makes these breadcrumbs much easier to read — `view[key=invoice-table].child[3]` is more useful than `view.child[3]`.
+
+## CORS
+
+The service is CORS-open (`*`). This is intended for browser-side template editors. If you proxy the service behind a gateway or use cookies, you will probably want to lock this down — the headers are set in [src/Server.ts](../src/Server.ts).
+
+## See also
+
+- [getting-started.md](getting-started.md) for a `curl` example end-to-end.
+- [elements.md](elements.md) for the shape of `pages[]`.
+- [deployment.md](deployment.md) for environment variables.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,76 @@
+# Deployment
+
+The service is a single Node process with no external dependencies (other than the optional Google Fonts API). The shipped Dockerfile produces a non-root release image.
+
+## Docker
+
+The [Dockerfile](../Dockerfile) defines three stages:
+
+| Stage         | Purpose                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| `pdf_debug`   | Empty stage extending a `pdf_base` image. Intended for `docker compose` mounts in dev. The host project is mounted at runtime, so the image itself stays empty. |
+| `pdf_build`   | Installs deps with `yarn --immutable`, copies `src/` and `fonts/`, runs `yarn build`, then runs `node-prune` to strip dev-only files from `node_modules`. |
+| `pdf_release` | The final stage. Creates a non-privileged `nodeuser`, copies `dist/`, `fonts/`, and `node_modules/` from `pdf_build`. Exposes port 9000. Entrypoint is `node dist/index.js`. |
+
+### Building
+
+```bash
+docker build --target pdf_release -t pdf-render-service .
+```
+
+### Running
+
+```bash
+docker run --rm -p 9000:9000 \
+  -e GOOGLEAPIKEY=your-key \
+  pdf-render-service
+```
+
+The release image runs as `nodeuser` (non-root) with `WORKDIR /app`.
+
+## Environment variables
+
+| Variable              | Required | Default | Purpose                                                                                |
+| --------------------- | -------- | ------- | -------------------------------------------------------------------------------------- |
+| `PORT`                | no       | `9000`  | Listen port.                                                                           |
+| `GOOGLEAPIKEY`        | conditional | _none_ | Required if the renders ever reference a font outside the bundled set. See [fonts.md](fonts.md). |
+| `VALIDATEAPIPAYLOADS` | no       | _unset_ | Set to `strict` to force JSON-schema validation on every request. See [api.md](api.md#validation). |
+
+## Logging
+
+Two `winston` transports are configured in [src/index.ts](../src/index.ts):
+
+- **Console** at `info` level (simple format).
+- **File** `pdf-renderer.log` at `warning` level (JSON format).
+
+In Docker, the file lives in `/app/pdf-renderer.log`. Mount a volume there if you want it persisted, or change the transport configuration.
+
+## Resource considerations
+
+- **Body cap**: 30 MB per request, enforced in [src/PdfController.ts](../src/PdfController.ts). Tune by editing the constant; raising it makes flood mitigation weaker.
+- **Tmp files**: each render writes a `<uuid>.pdf` into `${tmpdir()}/pdf-renderer/` and reads it back. The service does not currently delete these — clean up via container restarts or a periodic sweep on long-lived hosts.
+- **Memory**: large `data` payloads, large inline images, and big text trees all live in memory simultaneously. Under load, give the container enough headroom to absorb a 30 MB request plus working memory for layout.
+
+## Security notes
+
+### `vm2` is deprecated
+
+The `{{...}}` JS evaluation path uses [`vm2`](https://www.npmjs.com/package/vm2), which is no longer maintained and has a history of sandbox-escape CVEs. The renderer constrains the sandbox (`eval: false`, `wasm: false`, no `require`), which mitigates a lot but does not eliminate the risk.
+
+If you accept render requests from untrusted clients, treat the JS path as a soft attack surface. Options:
+
+- **Don't expose this service directly to untrusted users.** Front it with a service that owns templates and only exposes a parameterized API.
+- **Validate strictly.** Set `VALIDATEAPIPAYLOADS=strict` to reject malformed requests before they reach rendering.
+- **Track replacement.** A future migration off `vm2` (e.g. to `isolated-vm` or a hand-rolled expression evaluator that doesn't include a JS engine) is on the radar.
+
+### CORS is wide open
+
+The service responds with `Access-Control-Allow-Origin: *` for every request. This is intended to support browser-side template editors. Tighten this in [src/Server.ts](../src/Server.ts) before exposing the service on the public internet.
+
+### No auth
+
+There is no authentication. If you need it, terminate at a reverse proxy / API gateway in front of the service.
+
+## Health and readiness
+
+The `GET /` endpoint returns `SUCCESS` whenever the process can serve. It does not check downstream dependencies (the Google Fonts API in particular). For deeper readiness checks, point your probe at `/fonts` and assert that the bundled families are present.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1,0 +1,268 @@
+# Element Reference
+
+Every entry in `pages[]` is an element declaration. Containers nest other declarations through `children` (or `loop` for lists). This document describes every element type and every property the service understands.
+
+## Type inference
+
+If you omit `type`, the service infers it from which discriminator property is present.
+
+| Discriminator present       | Inferred `type` |
+| --------------------------- | --------------- |
+| Stack depth 1 (top of page) | `page`          |
+| `text`                      | `text`          |
+| `src`                       | `image`         |
+| `children`                  | `view`          |
+| `basis` **and** `loop`      | `list`          |
+
+Conflicting discriminators throw (e.g. `text` + `src` on the same node). For element types that have no discriminator (`link`, `shadow`) you must set `type` explicitly. Type-inference is in [src/factory/ElementFactory.tsx:279](../src/factory/ElementFactory.tsx#L279).
+
+## Common properties
+
+These apply to most or all element types.
+
+| Property    | Type                  | Where           | Notes                                                                                   |
+| ----------- | --------------------- | --------------- | --------------------------------------------------------------------------------------- |
+| `type`      | `ElementTypes`        | all             | Optional when inferable. One of `page`, `view`, `text`, `image`, `link`, `list`, `shadow`. |
+| `key`       | `string`              | all             | Stable identifier; appears in render-stack breadcrumbs as `<type>[key=...]`. Useful for debugging payloads. |
+| `comment`   | `string`              | all             | Free-form note. Ignored by the renderer; useful for hand-edited payloads.               |
+| `condition` | `string` (template)   | all             | When provided, the expression is evaluated; if falsy the element (and its subtree) is skipped. |
+| `fixed`     | `boolean` (template)  | all rendered    | Re-render this element on every page break. See [react-pdf fixed components](https://react-pdf.org/advanced#fixed-components). |
+| `break`     | `boolean` (template)  | all rendered    | Force a page break **before** this element.                                             |
+| `wrap`      | `boolean` (template)  | view, text, link, shadow | When `false`, the element is moved to the next page rather than split across pages. Default `true`. |
+| `style`     | `Style`               | stylable types  | Inline style object. See [styling.md](styling.md).                                      |
+| `classes`   | `string[]`            | stylable types  | Named styles applied in list order before `style`.                                      |
+| `debug`     | `boolean`             | stylable types  | Draw debug rectangles around this element. ORs with the request-level `debug` flag.     |
+
+"Template" boolean fields accept `true`/`false` or a string that resolves to one via `{{...}}` (e.g. `"{{data.shouldFix}}"`). **Caveat**: the wire types declare these as plain `boolean`, so the generated JSON schema rejects the string form. If you have `strict: true` (or `VALIDATEAPIPAYLOADS=strict`), use literal booleans or pre-resolve the value in your data.
+
+## `page`
+
+A page is the only element legal at the top level of `pages[]`.
+
+```json
+{
+  "type": "page",
+  "size": "LETTER",
+  "orientation": "portrait",
+  "style": { "padding": 36 },
+  "children": [ /* AnyElementDeclaration[] */ ]
+}
+```
+
+| Property      | Type                        | Notes                                                          |
+| ------------- | --------------------------- | -------------------------------------------------------------- |
+| `size`        | `StandardPageSize`          | Overrides request-level `size` for this page. If neither is set, falls back to the request-level default (`"Legal"`). |
+| `orientation` | `"portrait" \| "landscape"` | Overrides request-level `orientation`. Defaults to `"portrait"`. |
+| `children`    | `AnyElementDeclaration[]`   | Required.                                                      |
+| `style`       | `Style`                     | Page-level style (typically padding/margins, background).      |
+
+Pages always wrap (`wrap=true` is hardcoded). Only the request-level `debug` flag is honored on a page — a per-page `debug` is ignored. Other element types DO honor per-element `debug` (OR'd with the request flag).
+
+## `view`
+
+A flexbox-style container.
+
+```json
+{
+  "type": "view",
+  "style": { "display": "flex", "flexDirection": "row", "gap": 8 },
+  "children": [ /* ... */ ]
+}
+```
+
+| Property   | Type                      | Notes                                                              |
+| ---------- | ------------------------- | ------------------------------------------------------------------ |
+| `children` | `AnyElementDeclaration[]` | Required.                                                          |
+| `wrap`     | template boolean          | Default `true`.                                                    |
+
+Two common patterns:
+
+- **Flow layout**: `style.display = "flex"` plus `flexDirection`, `justifyContent`, etc.
+- **Absolute layout**: parent with `position: "relative"`, children with `position: "absolute"` and `top`/`left`/`right`/`bottom`.
+
+## `text`
+
+```json
+{
+  "type": "text",
+  "text": "Hello, {{data.name}}!",
+  "style": { "fontSize": 18, "color": "#000000" }
+}
+```
+
+| Property   | Type                              | Notes                                                                                                          |
+| ---------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `text`     | `string` (template)               | Body text. Mutually exclusive with `children`; if both are set, `text` is discarded with a logged warning.     |
+| `children` | `TextElementDeclaration[]`        | Inline text spans. Children must themselves be text nodes — use this for runs of mixed formatting in one line. |
+| `wrap`     | template boolean                  | Default `true`.                                                                                                |
+
+Text supports react-pdf's render-callback flow: page numbers (`pageNumber`, `totalPages`) are exposed as locals to your `text` template, so `"Page {{pageNumber}} of {{totalPages}}"` works.
+
+When the request sets `prerender: true`, the text content is pre-evaluated once with `pageNumber=100, totalPages=100` so paragraph measurement runs at layout time. Use this if your text template would otherwise produce empty layout boxes during the measurement pass.
+
+### Inline children example
+
+```json
+{
+  "type": "text",
+  "children": [
+    { "text": "Hello " },
+    { "text": "World", "style": { "fontWeight": "bold", "color": "blue" } },
+    { "text": "!" }
+  ]
+}
+```
+
+## `image`
+
+```json
+{
+  "src": "https://example.com/{{data.imageId}}.png",
+  "style": { "width": 200, "height": 100 }
+}
+```
+
+| Property | Type                 | Notes                                                                                |
+| -------- | -------------------- | ------------------------------------------------------------------------------------ |
+| `src`    | `string` (template)  | URL or `data:` URI. Required. Discriminator for type inference.                      |
+| `cache`  | template boolean     | Default `true`. Set to `false` to bypass react-pdf's image cache for this element.   |
+
+Images cannot have children. Inline `data:` URIs are supported; the body cap of 30 MB applies, so large inline payloads can hit the limit. See [api.md](api.md#limits).
+
+## `link`
+
+A clickable hyperlink. **Cannot be inferred** — set `type: "link"` explicitly.
+
+```json
+{
+  "type": "link",
+  "href": "https://example.com",
+  "text": "Visit example",
+  "style": { "color": "#0066cc" }
+}
+```
+
+| Property   | Type                              | Notes                                                          |
+| ---------- | --------------------------------- | -------------------------------------------------------------- |
+| `href`     | `string` (template)               | Destination URL. Required for the link to be useful.           |
+| `text`     | `string` (template)               | Link text. Mutually exclusive with `children`.                 |
+| `children` | `AnyElementDeclaration[]`         | Use when the link should wrap richer content (e.g. an image).  |
+| `wrap`     | template boolean                  | Default `true`.                                                |
+
+## `list`
+
+Logical iterator. Renders no element of its own — it expands into the items it produces. **Has no `style` of its own**; style your loop body or wrap the list in a `view`.
+
+```json
+{
+  "type": "list",
+  "basis": "data.items",
+  "header": { "type": "text", "text": "[Item Name] [Cost($)]", "fixed": true },
+  "loop":   { "type": "text", "text": "[{{$item.Name}}] [{{$item.Cost}}]" },
+  "footer": { "type": "image", "src": "https://example.com/sig.png" }
+}
+```
+
+| Property | Type                                       | Notes                                                                                                                |
+| -------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `basis`  | `string` (template, must resolve to array) | The collection to iterate. Any single-statement JS expression that yields an array is acceptable.                    |
+| `loop`   | `AnyElementDeclaration \| AnyElementDeclaration[]` | The element(s) emitted per iteration. Inside this subtree, `$item`, `$index`, and `$parent` are bound (see below).  |
+| `header` | `AnyElementDeclaration`                    | Optional. Rendered once before the iterations. Forced `fixed: true` so it repeats on each page break the list spans. |
+| `footer` | `AnyElementDeclaration`                    | Optional. Rendered once after the iterations. Same forced `fixed: true`.                                             |
+
+### Iteration locals
+
+Within `loop`, three locals are pushed onto the data scope:
+
+| Local     | Value                                                       |
+| --------- | ----------------------------------------------------------- |
+| `$item`   | The current element of the `basis` array.                   |
+| `$index`  | The 0-based index of the current iteration.                 |
+| `$parent` | The `$item` of the enclosing list (when lists are nested).  |
+
+See [src/factory/Elements/ListElementFactory.tsx:8](../src/factory/Elements/ListElementFactory.tsx#L8) for the source of truth.
+
+### Re-entrant headers/footers
+
+The whole point of `list` over a plain loop in client code: when the iterations span a page break, `header` and `footer` re-render at the top/bottom of every page the list touches. This makes table headers that repeat across pages a one-line declaration.
+
+## `shadow`
+
+A drop-shadowed text element. **Cannot be inferred** — set `type: "shadow"` explicitly.
+
+```json
+{
+  "type": "shadow",
+  "text": "BIG TITLE",
+  "style": {
+    "fontSize": 48,
+    "color": "#ffffff",
+    "shadowColor": "#000000",
+    "shadowOpacity": 0.5,
+    "shadowTranslate": 2
+  }
+}
+```
+
+| Property | Type                | Notes                                                                                |
+| -------- | ------------------- | ------------------------------------------------------------------------------------ |
+| `text`   | `string` (template) | Body text. Same `pageNumber`/`totalPages` locals as `text` elements.                 |
+| `wrap`   | template boolean    | Default `true`.                                                                      |
+
+Extra style properties (on top of normal `Style`):
+
+| Property             | Default     | Notes                                                                |
+| -------------------- | ----------- | -------------------------------------------------------------------- |
+| `shadowColor`        | `"#000000"` | The color of the offset shadow.                                      |
+| `shadowOpacity`      | `0.5`       | Opacity of the offset shadow.                                        |
+| `shadowTranslate`    | `1`         | Both X and Y offset (units are PDF points).                          |
+| `shadowTranslateX`   | inherits `shadowTranslate` | X offset only. Overrides `shadowTranslate` when set.  |
+| `shadowTranslateY`   | inherits `shadowTranslate` | Y offset only. Overrides `shadowTranslate` when set.  |
+
+Implementation detail: a `shadow` is a `view` containing two stacked `text` children — one positioned absolutely and offset (the shadow) and one positioned normally (the foreground). See [src/factory/Elements/ShadowElementFactory.tsx](../src/factory/Elements/ShadowElementFactory.tsx).
+
+## Putting it together
+
+A more complete request showing several elements working in concert:
+
+```json
+{
+  "title": "Invoice",
+  "size": "LETTER",
+  "data": {
+    "company": "Acme Co.",
+    "items": [
+      { "name": "Widget", "cost": 12.5 },
+      { "name": "Gadget", "cost": 7.0 }
+    ]
+  },
+  "styles": {
+    "h1": { "fontSize": 24, "fontWeight": "bold" },
+    "row": { "display": "flex", "flexDirection": "row", "justifyContent": "space-between" }
+  },
+  "pages": [
+    {
+      "type": "page",
+      "style": { "padding": 36 },
+      "children": [
+        { "type": "text", "classes": ["h1"], "text": "{{data.company}} — Invoice" },
+        {
+          "type": "list",
+          "basis": "data.items",
+          "header": { "type": "view", "classes": ["row"], "children": [
+            { "text": "Item" }, { "text": "Cost" }
+          ]},
+          "loop":   { "type": "view", "classes": ["row"], "children": [
+            { "text": "{{$item.name}}" }, { "text": "${{$item.cost.toFixed(2)}}" }
+          ]}
+        }
+      ]
+    }
+  ]
+}
+```
+
+## See also
+
+- [templating.md](templating.md) — what you can put inside `{{...}}`.
+- [styling.md](styling.md) — class precedence and supported CSS.

--- a/docs/fonts.md
+++ b/docs/fonts.md
@@ -1,0 +1,106 @@
+# Fonts
+
+Fonts are referenced by `fontFamily` inside a `style` block. The service ships three families pre-registered and fetches anything else from the Google Fonts API on demand.
+
+## Bundled defaults
+
+Three families are registered at module load and shipped in [fonts/](../fonts/):
+
+| Family      | Variants                                                                                              |
+| ----------- | ----------------------------------------------------------------------------------------------------- |
+| `Roboto`    | regular, bold, italic, bold italic                                                                    |
+| `Teko`      | light, normal, medium, semibold, bold                                                                 |
+| `Noto Sans` | thin, ultralight, light, normal, medium, semibold, bold, ultrabold, heavy — each with italic variants |
+
+These work with no configuration. See [src/fontManagement.ts](../src/fontManagement.ts) for the registration calls.
+
+## On-demand Google Fonts
+
+When an element references a `fontFamily` that isn't already registered, the renderer:
+
+1. Calls the [Google Fonts Developer API](https://developers.google.com/fonts/docs/developer_api) to find the family.
+2. Registers every variant Google returns, mapping numeric weights and `italic` flags to react-pdf's `fontWeight`/`fontStyle` enum.
+3. Records the family in the in-process `registeredFonts` map, so subsequent renders in this process skip the Google API call entirely.
+
+### Required: `GOOGLEAPIKEY`
+
+The service needs a Google API key with the **Web Fonts Developer API** enabled.
+
+```bash
+export GOOGLEAPIKEY=your-key-here
+yarn start
+```
+
+Without a valid key, any reference to a non-bundled family throws:
+
+```
+Exception thrown attempting to load a font 'Open Sans' from the Google API server.
+Check your API key (set via the GOOGLEAPIKEY environment variable).
+```
+
+To obtain a key: enable the Web Fonts API in a Google Cloud project and create an API key restricted to that service.
+
+### Variant mapping
+
+Google's variant strings map to react-pdf's `(fontWeight, fontStyle)` like this:
+
+| Google variant | `fontWeight` | `fontStyle` |
+| -------------- | ------------ | ----------- |
+| `100`          | `thin`       | `normal`    |
+| `200`          | `ultralight` | `normal`    |
+| `300`          | `light`      | `normal`    |
+| `400` / `regular` | `normal`  | `normal`    |
+| `500`          | `medium`     | `normal`    |
+| `600`          | `semibold`   | `normal`    |
+| `700`          | `bold`       | `normal`    |
+| `800`          | `ultrabold`  | `normal`    |
+| `900`          | `heavy`      | `normal`    |
+| `<weight>italic` / `italic` | as above | `italic` |
+
+When you write `fontWeight: "bold"` in a style, the renderer picks the matching variant; if no exact match exists, react-pdf falls back per its own rules.
+
+## Inspecting registered fonts
+
+```bash
+curl http://localhost:9000/fonts
+```
+
+Returns the families and `(weight, style)` configurations currently registered in this process. See [api.md](api.md#get-fonts).
+
+Note: registration only records that the source URL exists. Fonts aren't validated as actually loadable until the first time a render references them — a typo in a custom registration won't surface until rendering.
+
+## Using fonts in payloads
+
+```json
+{
+  "type": "text",
+  "text": "Sample",
+  "style": {
+    "fontFamily": "Open Sans",
+    "fontWeight": "bold",
+    "fontStyle": "italic",
+    "fontSize": 18
+  }
+}
+```
+
+If `Open Sans` isn't bundled, the service fetches it from Google Fonts before this element renders. The fetch is cached per process, so subsequent requests for the same family are free.
+
+## Adding a custom font at boot
+
+If you want a font that isn't on Google Fonts (or you don't want the runtime fetch), register it at startup. Drop the files into [fonts/](../fonts/) and add a `registerFont` call alongside the existing ones in [src/fontManagement.ts](../src/fontManagement.ts):
+
+```typescript
+registerFont('My Custom Font', [
+  { src: './fonts/MyCustom/MyCustom-Regular.ttf', fontWeight: 'normal' },
+  { src: './fonts/MyCustom/MyCustom-Bold.ttf',    fontWeight: 'bold'   },
+]);
+```
+
+`src` can also be a remote URL; `fontkit` handles the parse.
+
+## Caveats
+
+- **In-process registry**: each Node process has its own `registeredFonts` map. Fonts loaded on demand do not persist across restarts; they reload from Google Fonts after a redeploy.
+- **No invalidation**: the Google directory response is cached for the lifetime of a single render. If Google updates a family between renders you'd pick that up on the next request, not within one.
+- **Costs**: every cold-start request that references a new family adds ~one HTTP roundtrip to Google. For latency-sensitive paths, prefer bundling or pre-warming.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started
+
+This guide gets you from a fresh clone to a working PDF response in a few minutes.
+
+## Prerequisites
+
+- **Node.js 20.x** (the project pins 20.18.1 via Volta; the Docker image runs 20.19.5).
+- **Yarn 3 (Berry)** — `package.json` declares `packageManager: yarn@3.6.1`.
+- A **Google Fonts API key** if you intend to use any font outside the bundled defaults (Roboto, Teko, Noto Sans). See [fonts.md](fonts.md).
+
+## Install
+
+```bash
+git clone <this repo>
+cd pdf-render-service
+yarn
+```
+
+## Run the service
+
+```bash
+yarn start
+```
+
+This launches `ts-node-dev` with auto-respawn. By default the server listens on **port 9000**; override with the `PORT` environment variable.
+
+You should see `Server listening on port 9000` in the console.
+
+Other scripts:
+
+| Script              | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `yarn start`        | Dev mode with auto-respawn.                                        |
+| `yarn debug`        | Same, with `--inspect` for a debugger and `NODE_ENV=development`.  |
+| `yarn build`        | Compile TypeScript to `./dist`.                                    |
+| `yarn release`      | Build and run the compiled output.                                 |
+| `yarn lint`         | ESLint over `src/**/*.{ts,tsx}`.                                   |
+| `yarn update-types` | Regenerate the JSON schema in `src/resources/PdfRequest.json`.     |
+
+## Health check
+
+```bash
+curl http://localhost:9000/
+```
+
+Returns `SUCCESS` with HTTP 200 when the service is up.
+
+## Your first PDF
+
+Send a `POST` with a JSON body. The response is the PDF binary; pipe it to a file.
+
+```bash
+curl -X POST http://localhost:9000/ \
+  -H "Content-Type: application/json" \
+  -o hello.pdf \
+  -d '{
+    "title": "Hello World",
+    "size": "LETTER",
+    "orientation": "portrait",
+    "data": { "name": "World" },
+    "pages": [
+      {
+        "type": "page",
+        "style": { "padding": 36 },
+        "children": [
+          {
+            "type": "text",
+            "text": "Hello, {{data.name}}!",
+            "style": { "fontSize": 24 }
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+Open `hello.pdf` to see the result.
+
+## Where to go next
+
+- **[api.md](api.md)** — full endpoint reference and request envelope.
+- **[elements.md](elements.md)** — every element type and property.
+- **[templating.md](templating.md)** — `{{...}}` syntax and the data scope rules.
+- **[styling.md](styling.md)** — class application order and supported CSS.
+- **[fonts.md](fonts.md)** — bundled fonts and on-demand Google Fonts loading.
+- **[deployment.md](deployment.md)** — Docker, environment variables, security notes.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,0 +1,149 @@
+# Styling
+
+Layout uses [Yoga](https://yogalayout.com/) (flexbox) under the hood through `@react-pdf/renderer`. If you have web-CSS experience, most of it transfers directly.
+
+## What's supported
+
+The CSS subset is whatever react-pdf accepts — see the canonical list at [react-pdf.org/styling#valid-css-properties](https://react-pdf.org/styling#valid-css-properties). Common buckets:
+
+- **Box model**: `margin`, `padding`, `width`, `height`, `border`, etc.
+- **Flex layout**: `display: flex`, `flexDirection`, `justifyContent`, `alignItems`, `gap`, `flex`, `flexBasis`, `flexGrow`, `flexShrink`, `flexWrap`.
+- **Positioning**: `position: relative | absolute`, `top`, `right`, `bottom`, `left`.
+- **Typography**: `fontFamily`, `fontSize`, `fontWeight`, `fontStyle`, `color`, `textAlign`, `lineHeight`, `letterSpacing`, `textDecoration`, `textTransform`.
+- **Backgrounds & borders**: `backgroundColor`, `borderColor`, `borderRadius`, `borderStyle`, `borderWidth` (and per-side variants).
+- **Transforms**: `transform: "translateX(...) rotate(...)"`.
+
+What's **not** supported the way you'd expect on the web:
+
+- No CSS grid (Yoga is flexbox).
+- No pseudo-classes (`:hover`, `:nth-child`).
+- No media queries — there's only the page.
+- No animations.
+
+## Where styles go
+
+### Inline `style`
+
+Attached directly to an element:
+
+```json
+{
+  "type": "text",
+  "text": "Hello World",
+  "style": {
+    "fontSize": 18,
+    "color": "#000000",
+    "margin": 5,
+    "position": "absolute",
+    "top": 0,
+    "left": 0
+  }
+}
+```
+
+### Named classes
+
+Defined once in `styles` at the request level, applied via `classes` on any stylable element:
+
+```json
+{
+  "styles": {
+    "zeroPad":    { "margin": 0, "padding": 0 },
+    "smallPad":   { "padding": 2 },
+    "guideTitle": { "fontSize": 24, "fontWeight": "bold", "color": "#F7A03A" }
+  },
+  "pages": [
+    {
+      "type": "page",
+      "children": [
+        {
+          "type": "text",
+          "classes": ["zeroPad", "smallPad", "guideTitle"],
+          "style": { "color": "#000000" },
+          "text": "Title"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Precedence
+
+Unlike CSS specificity, application here is purely positional:
+
+1. `classes` are applied **in list order**. Later classes overwrite same-named properties from earlier ones.
+2. The element's own `style` is applied **last**, overriding any class.
+
+So in the example above:
+
+- `padding` resolves to `2` (smallPad overwrites zeroPad's `0`).
+- `color` resolves to `"#000000"` (inline `style` overrides `guideTitle`'s orange).
+
+The merge is implemented in [src/factory/ElementFactory.tsx:180](../src/factory/ElementFactory.tsx#L180) (`buildFinalStyle`).
+
+## Templated style values
+
+Every value in a `style` object can be a templated string — the wire type is `Style[Property] | string`. The string is evaluated through the same templating pipeline as text content:
+
+```json
+{
+  "style": {
+    "marginLeft": "{{data.standardMargin}}",
+    "color":      "{{$item.isActive ? '#0066cc' : '#999999'}}",
+    "fontSize":   "{{14 + data.zoom}}"
+  }
+}
+```
+
+Two extra locals are exposed inside style-string templates: `appliedStyle` (the class-merged style — *not* including any inline values) and `style` (the original inline `style` declaration). Use `appliedStyle.fontSize` to derive a value from class state. See [templating.md](templating.md#style-template-locals-inside-style-values).
+
+See [templating.md](templating.md) for the expression rules.
+
+## Common patterns
+
+### Two-column flow with gap
+
+```json
+{
+  "type": "view",
+  "style": { "display": "flex", "flexDirection": "row", "gap": 12 },
+  "children": [
+    { "type": "view", "style": { "flex": 1 }, "children": [ /* left */ ] },
+    { "type": "view", "style": { "flex": 1 }, "children": [ /* right */ ] }
+  ]
+}
+```
+
+### Absolute-positioned overlay
+
+```json
+{
+  "type": "view",
+  "style": { "position": "relative", "width": 200, "height": 200 },
+  "children": [
+    { "src": "https://example.com/bg.png", "style": { "position": "absolute", "top": 0, "left": 0, "width": 200, "height": 200 } },
+    { "type": "text", "text": "Overlay", "style": { "position": "absolute", "top": 8, "left": 8, "color": "white" } }
+  ]
+}
+```
+
+### Repeating page header (fixed)
+
+```json
+{
+  "type": "view",
+  "fixed": true,
+  "style": { "position": "absolute", "top": 12, "left": 12, "right": 12 },
+  "children": [
+    { "type": "text", "text": "Confidential — Page {{pageNumber}}/{{totalPages}}" }
+  ]
+}
+```
+
+`pageNumber` and `totalPages` are only available inside `text`/`shadow` text bodies — see [templating.md](templating.md#page-render-locals-text-shadow).
+
+## See also
+
+- [elements.md](elements.md) — which properties each element accepts.
+- [fonts.md](fonts.md) — using `fontFamily` correctly.

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1,0 +1,141 @@
+# Templating
+
+Any string field in a request payload (text body, image src, style values, even `basis`) supports `{{...}}` interpolation. The expression inside the braces resolves against the current data scope and is substituted into the string.
+
+## Two evaluation paths
+
+To keep the common case fast, the renderer tries a regex-based dereference first and only falls back to the JS sandbox for non-trivial expressions.
+
+### 1. Fast path — simple dereferences
+
+A pattern matching `[a-zA-Z_$][a-zA-Z0-9_.]+` is treated as a dotted property path on the scope. No JS engine is involved.
+
+```json
+{ "text": "{{data.user.name}}" }
+{ "text": "Hello {{$item.label}}" }
+```
+
+These run as a single object walk and are very fast.
+
+### 2. Sandboxed JS — anything else
+
+If anything in the substituted string still looks like `{{...}}` after the fast path runs, the remaining expressions are evaluated through [`vm2`](https://www.npmjs.com/package/vm2). The sandbox is configured with:
+
+| Setting   | Value     |
+| --------- | --------- |
+| `eval`    | `false`   |
+| `wasm`    | `false`   |
+| `timeout` | `150` ms  |
+| `sandbox` | the scope |
+
+Any single-statement JS expression that returns a stringifiable value works:
+
+```json
+{ "text": "{{[1,2,3,4].filter(i => i > 2).map(i => 'Index:' + (i+1))}}" }
+{ "text": "{{$item.cost.toFixed(2)}}" }
+{ "src":  "https://api.example.com/{{encodeURIComponent(data.query)}}" }
+```
+
+If a script throws, the thrown error is stringified and inserted in place of the expression — your PDF will visibly contain the error text rather than failing the render. Errors are also logged.
+
+> **Performance**: any string with at least one expression that reaches the JS path instantiates a fresh `vm2` VM (`condition` and `basis` evaluations each spin one up too). For documents with thousands of templates, prefer fast-path dereferences. A list iterating 1000 items where every cell uses an inline lambda will be noticeably slower than one that uses `{{$item.value}}`.
+
+## The data scope
+
+There are two layers:
+
+1. **Global scope** — the `PdfRequest` object itself, including `data`, `styles`, `title`, etc.
+2. **Local scope stack** — additional frames pushed by container elements (currently just `list`).
+
+When templates are evaluated, the **top local frame is merged with the global scope**, with the local frame taking precedence. So inside a list iteration `data.X` is still reachable, and `$item` etc. shadow any same-named keys from the global scope.
+
+The scope merge is implemented in [src/factory/ElementFactory.tsx](../src/factory/ElementFactory.tsx) — see `finalizeStringDeferred` and the `scope` getter.
+
+### Globals you can reach
+
+Anything you put in the request top level is reachable. The most common:
+
+| Reference                | What it resolves to                                                  |
+| ------------------------ | -------------------------------------------------------------------- |
+| `data`                   | Your `data` payload.                                                 |
+| `data.something`         | A field on it.                                                       |
+| `title`, `size`, etc.    | The corresponding top-level request fields.                          |
+| `styles.someClass`       | A registered class object (rarely needed in templates).              |
+
+### List-iteration locals
+
+Inside a `list`'s `loop`, `header`, or `footer` subtree:
+
+| Local     | Value                                                            |
+| --------- | ---------------------------------------------------------------- |
+| `$item`   | The current element of the `basis` array.                        |
+| `$index`  | The 0-based iteration index.                                     |
+| `$parent` | The `$item` of the enclosing list (for nested lists).            |
+
+`$parent` only carries one level up — if you nest three lists deep and need the outermost item, you'd need to project it down via the data shape.
+
+### Page-render locals (text, shadow)
+
+When a `text` or `shadow` element renders, react-pdf supplies render-time locals exposed to your templates:
+
+| Local         | Value                                            |
+| ------------- | ------------------------------------------------ |
+| `pageNumber`  | The page this element lands on (1-based).        |
+| `totalPages`  | Total page count of the document.                |
+
+Example:
+
+```json
+{ "type": "text", "fixed": true, "text": "Page {{pageNumber}} of {{totalPages}}" }
+```
+
+These are only defined inside `text`/`shadow` `text` properties. Outside that context they're undefined.
+
+### Style-template locals (inside `style` values)
+
+When a string value inside a `style` block is finalized, two extra locals are exposed:
+
+| Local          | Value                                                          |
+| -------------- | -------------------------------------------------------------- |
+| `appliedStyle` | The class-merged style for this element (no inline values yet). |
+| `style`        | The original inline `style` declaration as written.            |
+
+This lets a templated value reference the class-derived state, e.g. `"{{appliedStyle.fontSize * 1.5}}"`. Note that `appliedStyle` does **not** update incrementally as other inline-style strings are evaluated — every inline value sees the same class-only snapshot.
+
+## Where templates can appear
+
+Anywhere the schema accepts a string. Concretely:
+
+- `text`, `href`, `src`, `basis`, `condition`.
+- All values inside `style` (the type is `Style[Property] | string` to allow this; see [src/wire/ElementDeclaration.ts:17](../src/wire/ElementDeclaration.ts#L17)).
+- `key`, `comment` (technically allowed; rarely useful).
+- The boolean-template fields `fixed`, `break`, `wrap`, `cache`, `debug` accept strings that resolve to booleans.
+
+## `condition`
+
+`condition` is a special template field that gates whether an element renders.
+
+```json
+{
+  "type": "view",
+  "condition": "data.user.isAdmin",
+  "children": [
+    { "text": "Admin-only content" }
+  ]
+}
+```
+
+The expression is evaluated through the JS sandbox; truthy values render the subtree, falsy values skip it entirely. This is useful for optional sections, debug-only blocks, and per-environment branching.
+
+## Limits and gotchas
+
+- **150 ms script timeout** is per-expression, not per-render. A single `{{...}}` that loops too long will be killed and the error stringified into your output.
+- **Only single-statement expressions** work cleanly — `vm2.run` evaluates as an expression. Statements (`if`, declarations) won't return a value.
+- **No I/O**, **no `require`**, **no eval**, **no wasm**. The sandbox cannot read files, hit networks, or load modules.
+- **Errors don't fail the request** — they appear in the output text. If you need a request to fail when a template fails, validate your data before sending or use `condition` to skip clearly-broken branches.
+- **Nested braces** (e.g. `{{ {a:1}.a }}`) work via the sandbox path because the regex extracts greedily-then-non-greedily; if you need literal `{{` in your output, you currently can't escape them.
+
+## See also
+
+- [elements.md](elements.md) for the elements that consume templated values.
+- [styling.md](styling.md) for templated style values.

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,24 @@
+# Product Context
+
+## Problem
+Generating PDFs with dynamic content (variable-length lists, templated titles, repeating table headers across page breaks) is poorly served by existing tools. HTML-to-PDF converters either don't support repeating headers across pages or break under browser updates. Static PDF editors can't accept dynamic data.
+
+## Solution
+A render service driven by a single JSON document describing:
+- `data` — the values to bind into the PDF.
+- `styles` — named style classes, applied in list order with later classes overriding earlier ones, and inline `style` overriding all classes.
+- `pages` — the element tree (pages, views, text, images, lists, links, shadow elements).
+
+Templating with `{{expression}}` lets any string property reference data or run a sandboxed JS expression. List elements iterate over array data and may re-emit headers/footers across page breaks.
+
+## Functional Intent
+- Accept a `PdfRequest` JSON body via POST and stream a PDF binary back.
+- Infer element types from discriminator properties (`text`, `src`, `children`, `basis`+`loop`) so simple cases stay terse.
+- Load Google Fonts on demand when a referenced family isn't already registered (Roboto, Teko, Noto Sans ship preregistered).
+- Optionally validate payloads against the generated JSON schema; fail fast with a 400 when strict.
+
+## UX Expectations
+- **Consumers are programmatic** — backends or a future template editor, not browsers directly. Errors return HTTP status codes plus a plaintext body that includes a render-stack breadcrumb when generation fails mid-tree.
+- **Filename comes from `title`** — sanitized and used for `Content-Disposition`.
+- **Cross-origin** — CORS open (`*`) so a browser-side editor can call it.
+- **Timeouts on templating** — embedded JS runs in vm2 with a 150ms timeout to keep the service responsive.

--- a/memory-bank/projectBrief.md
+++ b/memory-bank/projectBrief.md
@@ -1,0 +1,21 @@
+# Project Brief: pdf-render-service
+
+## Purpose
+A PDF layout and rendering engine plus an HTTP service that renders PDFs on-demand from a JSON request payload.
+
+## Why
+Existing tools (wkhtmltopdf, headless-Chromium services) cannot reliably handle re-entrant headers/footers on variable-length content (e.g. a table whose header row repeats on each page break). They are also fragile under upstream browser updates. This service owns the rendering path so it can be debugged and fixed in-house.
+
+## Requirements
+- **Data-driven structure and content** — both the layout tree and the values inside it come from the request payload, not hardcoded templates.
+- **Templating** — `{{...}}` interpolation in any string field, supporting simple dereferences and arbitrary single-statement JS (sandboxed).
+- **Re-entrant blocks** — list elements may declare `header` and `footer` that re-render on every page break the list spans.
+- **Service-shaped** — POST a JSON body, get a PDF binary back. CORS-enabled. GET `/` for health, GET `/fonts` for registered fonts.
+- **Schema validation** — opt-in strict validation against a generated JSON schema for `PdfRequest`.
+
+## Scope
+- IN: JSON-to-PDF rendering, dynamic font loading from Google Fonts, layout via react-pdf/Yoga, the HTTP wrapper.
+- OUT (future): graphical template editor — the data-driven model exists to enable this later, but it is not part of this repo.
+
+## End Goal
+Enable a future visual template editor by keeping data and structure separable, and let non-developers edit PDF templates without redeploying.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,44 @@
+# System Patterns
+
+## Architecture
+Single-process Node HTTP server. No framework — raw `http.createServer`. Three layers:
+
+1. **Transport** — [src/index.ts](src/index.ts) wires winston + the listener. [src/Server.ts](src/Server.ts) routes by method/url and instantiates a controller per POST.
+2. **Controller** — [src/PdfController.ts](src/PdfController.ts) buffers the body (30MB cap), parses JSON, optionally validates, hands off to the factory, renders to a tmp file, streams the bytes back.
+3. **Factory + Elements** — [src/factory/ElementFactory.tsx](src/factory/ElementFactory.tsx) walks the JSON tree and produces a react-pdf React element tree. Each element type has its own factory in [src/factory/Elements/](src/factory/Elements/) and is registered in [src/factory/ElementRegistry.tsx](src/factory/ElementRegistry.tsx).
+
+## Major Design Choices
+- **react-pdf as the renderer** — layout is Yoga (flexbox-ish CSS subset); no headless browser.
+- **JSON schema generation, not runtime types** — `yarn update-types` runs `ts-json-schema-generator` over [src/wire/PdfRequest.ts](src/wire/PdfRequest.ts) into [src/resources/PdfRequest.json](src/resources/PdfRequest.json). Validation uses ajv in [src/validatePdfRequest.ts](src/validatePdfRequest.ts).
+- **vm2 sandbox for templating** — `{{...}}` first tries a fast regex dereference; if anything remains, evaluate via vm2 with `eval:false`, `wasm:false`, 150ms timeout.
+- **Two-stage scope** — global config + a stack of local scopes (pushed/popped by list elements via `pushData`/`popData` on the factory). `$item` and friends live in the top frame.
+- **Tmp-file round-trip** — `ReactPDF.render` writes to disk because there's no in-memory API; the controller reads it back and streams it.
+- **Render stack on errors** — `createElementKey` builds a breadcrumb; thrown errors get a `renderStack` array attached and surfaced in the 400 response.
+
+## Component Relationships
+```
+index.ts → Server.ts → PdfController
+                          │
+                          ├─ validatePdfRequest (ajv)
+                          └─ ElementFactory ──▶ ElementRegistry ──▶ Elements/{Page,View,Text,Image,Link,List,Shadow}
+                                  │
+                                  ├─ fontManagement (loadReferencedFonts, registerFont)
+                                  ├─ vm2 (templating)
+                                  └─ helpers/FinalizeHelpers
+```
+
+## Critical Flows
+
+### Render flow (POST /)
+1. Buffer body, abort if >30MB.
+2. `JSON.parse` → `PdfRequest`.
+3. If `strict` flag (request) or `VALIDATEAPIPAYLOADS=strict` (env) → ajv validate, 400 on failure.
+4. `ElementFactory.generate()` walks `pages[]`, dispatching each declaration through the registry; `<Document>` wraps the result.
+5. `ReactPDF.render(tree, tmpPath)` writes the PDF.
+6. Read file, set `Content-type: application/pdf` + `Content-Disposition` (sanitized title), stream back.
+
+### Type inference
+When `type` is omitted, `ElementFactory.inferElementType` picks one based on which discriminator property is present (`text` → text, `src` → image, `children` → view, `basis`+`loop` → list). At stack depth 1 the default is `page`. Conflicting discriminators throw.
+
+### Font loading
+`loadUnregisteredFonts(fontFamily)` checks the in-memory `registeredFonts` map; if missing, `loadReferencedFonts` hits the Google Fonts API (cached per-request after the first call) and `Font.register`s every variant returned.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,52 @@
+# Tech Context
+
+## Stack
+- **Runtime**: Node.js 20.19.5 (Volta pins 20.18.1 for local dev).
+- **Language**: TypeScript 5.7, `target: ES6`, `module: commonjs`, `strict: true`, `jsx: react`.
+- **Renderer**: `@react-pdf/renderer` ^3.4.5 (Yoga layout under the hood) + `react` 16.12.
+- **Validation**: `ajv` ^8 against a JSON schema generated from TS types via `ts-json-schema-generator`.
+- **Templating sandbox**: `vm2` ^3.10 (`eval:false`, `wasm:false`, 150ms timeout per script).
+- **Logging**: `winston` (console at info, file `pdf-renderer.log` at warning).
+- **HTTP**: stdlib `http`, `cors` package present in deps but the routing in [src/Server.ts](src/Server.ts) sets CORS headers manually.
+- **Other**: `axios` (Google Fonts API), `fontkit`, `uuid`.
+- **Package manager**: yarn 3.6.1 (Berry).
+
+## Constraints
+- **Body limit**: 30MB per POST (data-URI inline images can be large). Exceeding this destroys the connection.
+- **Script timeout**: 150ms per `{{...}}` evaluation in vm2.
+- **No in-memory render**: react-pdf forces a tmp-file round-trip (`os.tmpdir()/pdf-renderer/<uuid>.pdf`).
+- **`vm2` is deprecated upstream** — known security history; constrained sandbox config (no eval, no wasm) mitigates but doesn't eliminate. Replacing it would be a non-trivial migration.
+
+## Setup
+```bash
+yarn                # install (yarn 3, immutable in CI)
+yarn start          # ts-node-dev with auto-respawn
+yarn build          # tsc → ./dist
+yarn release        # build + run compiled output
+yarn debug          # tsnd with --inspect (TZ=UTC, NODE_ENV=development)
+yarn lint           # eslint over src/**/*.{ts,tsx}
+yarn update-types   # regenerate src/resources/PdfRequest.json from PdfRequest.ts
+```
+
+Default port: `9000`, override via `PORT`.
+
+## Environment Variables
+- `PORT` — listen port (default 9000).
+- `GOOGLEAPIKEY` — Google Fonts API key for on-demand font loading.
+- `VALIDATEAPIPAYLOADS` — set to `strict` to force ajv validation on every request (otherwise per-request `strict: true` opts in).
+
+## Deployment
+Multi-stage Dockerfile in [Dockerfile](Dockerfile):
+- `pdf_debug` extends a base image and is intended for compose-mounted dev.
+- `pdf_build` installs immutable deps, builds, runs `node-prune`.
+- `pdf_release` runs as non-root `nodeuser`, exposes port 9000, entrypoint `node dist/index.js`.
+
+## Tooling Patterns
+- **Schema-from-types** — `PdfRequest.ts` is the source of truth; `PdfRequest.json` is generated. Don't hand-edit the JSON.
+- **Element registration** — new element kinds need a factory in [src/factory/Elements/](src/factory/Elements/) plus an entry in [src/factory/ElementRegistry.tsx](src/factory/ElementRegistry.tsx).
+- **Default fonts** — Roboto, Teko, and Noto Sans are bundled under [fonts/](fonts/) and registered at module load in [src/fontManagement.ts](src/fontManagement.ts); anything else is fetched from Google Fonts at request time.
+
+## Dependencies of note
+- `vm2` — sandbox; deprecated, watch for replacement effort.
+- `react` 16 — pinned by react-pdf compatibility; do not upgrade independently.
+- `@react-pdf/types` — drives `Style`, `StandardPageSize`, `Orientation` types referenced from wire definitions.


### PR DESCRIPTION
## Summary

- Slim the README to a pitch + quickstart + TOC and move depth into a new `docs/` folder.
- Add seven human-targeted guides covering API, elements, templating, styling, fonts, deployment, and getting started.
- Promote `memory-bank/` from gitignored to tracked as the LLM-targeted snapshot, mirrored against `docs/`.
- Fix a broken `../CODE_OF_CONDUCT.md` link in `Contributing.md` (was resolving outside the repo).

## Why

The previous README mixed pitch, tutorial, and reference. While reviewing it I found:
- **Missing element types**: `link` and `shadow` were never documented.
- **Missing properties**: `condition`, `break`, `key`, `wrap`, `debug`, `cache`, `prerender`, per-page `size`/`orientation`, list-iteration locals (`$item`, `$index`, `$parent`).
- **Stale claims**: README said `if` was "the next candidate" when `condition` was already implemented.
- **No quickstart**: setup instructions only existed in the LLM-targeted memory-bank.
- **Broken JSON examples**: trailing commas in code samples that readers would copy-paste and have fail.
- **Endpoints undocumented**: `GET /fonts` was never mentioned.
- **Templating internals missing**: vm2 sandbox, 150ms timeout, scope merge rules.

## What's in `docs/`

- `getting-started.md` — install, run, first `curl` POST returning a PDF.
- `api.md` — endpoints, full `PdfRequest` envelope, error responses, render-stack breadcrumb format, body cap, CORS.
- `elements.md` — every element type and every property, with type-inference rules and a runnable invoice example.
- `templating.md` — fast path vs vm2 path, sandbox limits, scope stack, page-render and style-template locals, gotchas.
- `styling.md` — class precedence, supported CSS subset, templated style values, common patterns.
- `fonts.md` — bundled defaults, `GOOGLEAPIKEY`, on-demand Google Fonts loading, variant mapping, custom registration.
- `deployment.md` — Dockerfile stages, env vars, vm2-deprecation security note, CORS-open warning.

`memory-bank/` is preserved as the terse, LLM-targeted view; humans should prefer `docs/`.

## Test plan

- [ ] Click through every link in README and the new `docs/` files; confirm no 404s and that anchor links resolve.
- [ ] Copy-paste the `curl` from `docs/getting-started.md` against a running server and confirm a valid PDF returns.
- [ ] Run the larger invoice example from `docs/elements.md` and confirm it renders.
- [ ] Verify `GET /fonts` output matches `docs/api.md`'s shape.
- [ ] Skim `docs/elements.md` against the actual `src/factory/Elements/*.tsx` to spot-check property accuracy.